### PR TITLE
Fix: Correct certificate generation implementation in generator.rs

### DIFF
--- a/backend/src/certificate/generator.rs
+++ b/backend/src/certificate/generator.rs
@@ -1,19 +1,23 @@
-use rcgen::generate_simple_self_signed;
+use rcgen::{generate_simple_self_signed, CertifiedKey};
 use std::fs::File;
 use std::io::Write;
 use std::error::Error;
 
 pub fn generate_cert_and_key() -> Result<(), Box<dyn Error>> {
     let subject_alt_names = vec!["localhost".to_string(), "device.local".to_string()];
-    let cert = generate_simple_self_signed(subject_alt_names)?;
+    let CertifiedKey { cert, key_pair } = generate_simple_self_signed(subject_alt_names)
+        .map_err(|e| {
+            eprintln!("Failed to generate self-signed certificate: {}", e);
+            e
+        })?;
 
     // Write the certificate to `cert.pem`
     let mut cert_file = File::create("cert.pem")?;
-    cert_file.write_all(cert.serialize_pem()?.as_bytes())?;
+    cert_file.write_all(cert.pem().as_bytes())?;
 
     // Write the private key to `key.pem`
     let mut key_file = File::create("key.pem")?;
-    key_file.write_all(cert.serialize_private_key_pem().as_bytes())?;
+    key_file.write_all(key_pair.serialize_pem().as_bytes())?;
 
     Ok(())
 }


### PR DESCRIPTION
**Bug Fix in Certificate Generation**:
   - Corrected the implementation in `generator.rs` to output valid `cert.pem` and `key.pem` files.
   - Previously, the generated certificate and key were not in the correct format, resulting in server startup issues.

Resolves #4 